### PR TITLE
Fixed issue where EDP codes with a letter at the 2nd position (e.g., …

### DIFF
--- a/app/Http/Controllers/admin/masters/EdpController.php
+++ b/app/Http/Controllers/admin/masters/EdpController.php
@@ -45,7 +45,7 @@ class EdpController extends Controller
     {
         $moduleName = "Create EDP";
         $validate = $request->validate([
-            'edp_code' => ['required', 'unique:edps', 'regex:/^(?:[A-Za-z]{2,3}\d{6,7}|\d{9})$/'],
+            'edp_code' => ['required', 'unique:edps', 'regex:/^(?:[A-Za-z]{2,3}\d{6,7}|\d[A-Za-z]\d{7}|\d{9})$/'],
             'section' => 'required|string',
             'measurement' => 'required',
             'description' => 'required',
@@ -57,7 +57,7 @@ class EdpController extends Controller
 
         $materialGroup = strtoupper(substr($request->edp_code, 0, 2));
         // Determine category based on material group
-        if ($materialGroup === 'OC') {
+        if ($materialGroup === '0C') {
             $category = 'capital';
         } elseif (ctype_digit($materialGroup)) {
             $groupNum = intval($materialGroup);
@@ -66,7 +66,7 @@ class EdpController extends Controller
             } elseif ($groupNum >= 21 && $groupNum <= 42) {
                 $category = 'spares';
             } else {
-                $category = 'unknown';
+                $category = 'unknown'; 
             }
         } else {
             $category = 'unknown';

--- a/resources/views/admin/edp/create.blade.php
+++ b/resources/views/admin/edp/create.blade.php
@@ -95,12 +95,12 @@
         $(document).ready(function() {
             $("form").on("submit", function(e) {
                 let edpCode = $("input[name='edp_code']").val();
-                let regex = /^(?:[A-Za-z]{2,3}\d{6,7}|\d{9})$/; // 9 digits OR 2-3 letters + 6-7 digits
+               let regex = /^(?:\d{9}|\d[A-Za-z]\d{7})$/;
 
                 if (!regex.test(edpCode)) {
                     e.preventDefault(); // Stop form submission
                     $("#edpError").text(
-                            "EDP Code must be 9 digits OR start with 2-3 letters followed by 6-7 digits.")
+                            "EDP Code must be either exactly 9 digits or start with 1 digit, followed by 1 letter, and then 7 digits. E.g., 123456789 or 0C5103000.")
                         .show();
                 } else {
                     $("#edpError").hide();


### PR DESCRIPTION
…0C5103000 for capital items) were incorrectly marked as "unknown" and triggered an invalid error message. Updated the validation to accept this format and correctly classify EDPs starting with "0C" as capital items.